### PR TITLE
Added support for fields

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# Editor config for project, supported by many editors.
+# See http://editorconfig.org/
+# Visual Studio Extension: https://visualstudiogallery.msdn.microsoft.com/c8bccfe2-650c-4b42-bc5c-845e21f96328
+
+[*.cs]
+tab_width=4
+indent_style=space
+indent_size=4
+trim_trailing_whitespace=true

--- a/BetterPrivateObject.Tests/PrivateObjectTests.cs
+++ b/BetterPrivateObject.Tests/PrivateObjectTests.cs
@@ -126,8 +126,90 @@ namespace BetterPrivateObject.Tests
             Assert.IsTrue(true);
         }
 
+        [TestMethod]
+        public void GetPublicFieldValue()
+        {
+            dynamic subjectPO = new PrivateObject<Subject>();
+
+            int actual = subjectPO.publicField;
+
+            Assert.AreEqual(Subject.FieldInitialValue, actual);
+        }
+
+        [TestMethod]
+        public void SetPublicFieldValue()
+        {
+            dynamic subjectPO = new PrivateObject<Subject>();
+
+            const int newValue = 5;
+            subjectPO.publicField = newValue;
+            int actual = subjectPO.publicField;
+
+            Assert.AreEqual(newValue, actual);
+        }
+
+        [TestMethod]
+        public void GetPrivateFieldValue()
+        {
+            dynamic subjectPO = new PrivateObject<Subject>();
+
+            int actual = subjectPO.privateField;
+
+            Assert.AreEqual(Subject.FieldInitialValue, actual);
+        }
+
+        [TestMethod]
+        public void SetPrivateFieldValue()
+        {
+            dynamic subjectPO = new PrivateObject<Subject>();
+
+            const int newValue = 5;
+            subjectPO.privateField = newValue;
+            int actual = subjectPO.privateField;
+
+            Assert.AreEqual(newValue, actual);
+        }
+
+        [TestMethod]
+        public void GetPrivateReadonlyFieldValue()
+        {
+            dynamic subjectPO = new PrivateObject<Subject>();
+
+            int actual = subjectPO.privateReadonlyField;
+
+            Assert.AreEqual(Subject.FieldInitialValue, actual);
+        }
+
+        /// <summary>
+        /// Since reflection allows setting readonly fields, why shouldn't we?
+        /// </summary>
+        [TestMethod]
+        public void SetPrivateReadonlyFieldValue()
+        {
+            dynamic subjectPO = new PrivateObject<Subject>();
+
+            const int newValue = 5;
+            subjectPO.privateReadonlyField = newValue;
+            int actual = subjectPO.privateReadonlyField;
+
+            Assert.AreEqual(newValue, actual);
+        }
+
         public class Subject
         {
+            public const int FieldInitialValue = 42;
+
+            public int publicField;
+            private int privateField;
+            private readonly int privateReadonlyField;
+
+            public Subject()
+            {
+                publicField = FieldInitialValue;
+                privateField = FieldInitialValue;
+                privateReadonlyField = FieldInitialValue;
+            }
+
             private bool privateMethodThatResturnsBoolean() { return true; }
             private bool privateMethodThatReturnsBooleanWithParameter(bool p1) { return p1; }
             private void privateVoidMethod() { }

--- a/BetterPrivateObject.Tests/PrivateTypeTests.cs
+++ b/BetterPrivateObject.Tests/PrivateTypeTests.cs
@@ -110,7 +110,7 @@ namespace BetterPrivateObject.Tests
 
             Assert.IsTrue(true);
         }
-        
+
         [TestMethod]
         public void GetPublicStaticPropertyValue()
         {
@@ -131,8 +131,90 @@ namespace BetterPrivateObject.Tests
             Assert.IsTrue(true);
         }
 
+        [TestMethod]
+        public void GetPublicStaticFieldValue()
+        {
+            dynamic subjectPO = new PrivateType<Subject>();
+
+            int actual = subjectPO.publicStaticField;
+
+            Assert.AreEqual(Subject.FieldInitialValue, actual);
+        }
+
+        [TestMethod]
+        public void SetPublicStaticFieldValue()
+        {
+            dynamic subjectPO = new PrivateType<Subject>();
+
+            const int newValue = 5;
+            subjectPO.publicStaticField = newValue;
+            int actual = subjectPO.publicStaticField;
+
+            Assert.AreEqual(newValue, actual);
+        }
+
+        [TestMethod]
+        public void GetPrivateStaticFieldValue()
+        {
+            dynamic subjectPO = new PrivateType<Subject>();
+
+            int actual = subjectPO.privateStaticField;
+
+            Assert.AreEqual(Subject.FieldInitialValue, actual);
+        }
+
+        [TestMethod]
+        public void SetPrivateStaticFieldValue()
+        {
+            dynamic subjectPO = new PrivateType<Subject>();
+
+            const int newValue = 5;
+            subjectPO.privateStaticField = newValue;
+            int actual = subjectPO.privateStaticField;
+
+            Assert.AreEqual(newValue, actual);
+        }
+
+        [TestMethod]
+        public void GetPrivateStaticReadonlyFieldValue()
+        {
+            dynamic subjectPO = new PrivateType<Subject>();
+
+            int actual = subjectPO.privateStaticReadonlyField;
+
+            Assert.AreEqual(Subject.FieldInitialValue, actual);
+        }
+
+        /// <summary>
+        /// Since reflection allows setting readonly fields, why shouldn't we?
+        /// </summary>
+        [TestMethod]
+        public void SetPrivateStaticReadonlyFieldValue()
+        {
+            dynamic subjectPO = new PrivateType<Subject>();
+
+            const int newValue = 5;
+            subjectPO.privateStaticReadonlyField = newValue;
+            int actual = subjectPO.privateStaticReadonlyField;
+
+            Assert.AreEqual(newValue, actual);
+        }
+
         public class Subject
         {
+            public const int FieldInitialValue = 42;
+
+            public static int publicStaticField;
+            private static int privateStaticField;
+            private static readonly int privateStaticReadonlyField;
+
+            static Subject()
+            {
+                publicStaticField = FieldInitialValue;
+                privateStaticField = FieldInitialValue;
+                privateStaticReadonlyField = FieldInitialValue;
+            }
+
             private static bool privateStaticMethodThatResturnsBoolean() { return true; }
             private static bool privateStaticMethodThatReturnsBooleanWithParameter(bool p1) { return p1; }
             private static void privateStaticVoidMethod() { }

--- a/BetterPrivateObject/PrivateObject.cs
+++ b/BetterPrivateObject/PrivateObject.cs
@@ -35,16 +35,27 @@ namespace BetterPrivateObject
 			result = method.Invoke(Container, args);
 			return true;
 		}
-        
+
         public override bool TryGetMember(GetMemberBinder binder, out object result)
         {
             PropertyInfo property = typeof(T).GetProperty(binder.Name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
             if (property == null)
             {
-                result = null;
-                return false;
+                FieldInfo field = typeof(T).GetField(binder.Name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                if (field == null)
+                {
+                    result = null;
+                    return false;
+                }
+                else
+                {
+                    result = field.GetValue(Container);
+                }
             }
-            result = property.GetValue(Container, null);
+            else
+            {
+                result = property.GetValue(Container, null);
+            }
             return true;
         }
 
@@ -53,9 +64,20 @@ namespace BetterPrivateObject
             PropertyInfo property = typeof(T).GetProperty(binder.Name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
             if (property == null)
             {
-                return false;
+                FieldInfo field = typeof(T).GetField(binder.Name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                if (field == null)
+                {
+                    return false;
+                }
+                else
+                {
+                    field.SetValue(Container, value);
+                }
             }
-            property.SetValue(Container, value, null);
+            else
+            {
+                property.SetValue(Container, value, null);
+            }
             return true;
         }
     }

--- a/BetterPrivateObject/PrivateType.cs
+++ b/BetterPrivateObject/PrivateType.cs
@@ -38,10 +38,21 @@ namespace BetterPrivateObject
             PropertyInfo property = typeof(T).GetProperty(binder.Name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
             if (property == null)
             {
-                result = null;
-                return false;
+                FieldInfo field = typeof(T).GetField(binder.Name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+                if (field == null)
+                {
+                    result = null;
+                    return false;
+                }
+                else
+                {
+                    result = field.GetValue(null);
+                }
             }
-            result = property.GetValue(null, null);
+            else
+            {
+                result = property.GetValue(null, null);
+            }
             return true;
         }
 
@@ -50,9 +61,20 @@ namespace BetterPrivateObject
             PropertyInfo property = typeof(T).GetProperty(binder.Name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
             if (property == null)
             {
-                return false;
+                FieldInfo field = typeof(T).GetField(binder.Name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+                if (field == null)
+                {
+                    return false;
+                }
+                else
+                {
+                    field.SetValue(null, value);
+                }
             }
-            property.SetValue(null, value, null);
+            else
+            {
+                property.SetValue(null, value, null);
+            }
             return true;
         }
     }


### PR DESCRIPTION
Hi again,

this time I added support for fields. I should have added this last time together with properties. There might be a debate whether or not it is wise to access fields in tests but this should be the decision of the user.

I also added a .editorconfig file because I usually have different editor settings.